### PR TITLE
feat: support peek_many and pop_many

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1,7 +1,7 @@
 //! A module for storing key-value pairs in flash with minimal erase cycles.
 //!
 //! When a key-value is stored, it overwrites the any old items with the same key.
-//! 
+//!
 //! Make sure to use the same [StorageItem] type on a given range in flash.
 //! In theory you could use multiple types if you're careful, but they must at least have the same key definition and format.
 //!

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -166,10 +166,7 @@ pub fn push<S: NorFlash>(
 /// If you also want to remove the data use [pop_many].
 ///
 /// Returns an iterator-like type that can be used to peek into the data.
-pub fn peek_many<'d, S: NorFlash>(
-    flash: &'d mut S,
-    flash_range: Range<u32>,
-) -> PeekIterator<'d, S> {
+pub fn peek_many<S: NorFlash>(flash: &mut S, flash_range: Range<u32>) -> PeekIterator<'_, S> {
     PeekIterator {
         iter: QueueIterator::new(flash, flash_range),
     }
@@ -198,10 +195,10 @@ pub fn peek<'d, S: NorFlash>(
 /// If you don't want to remove the data use [peek_many].
 ///
 /// Returns an iterator-like type that can be used to pop the data.
-pub fn pop_many<'d, S: MultiwriteNorFlash>(
-    flash: &'d mut S,
+pub fn pop_many<S: MultiwriteNorFlash>(
+    flash: &mut S,
     flash_range: Range<u32>,
-) -> PopIterator<'d, S> {
+) -> PopIterator<'_, S> {
     PopIterator {
         iter: QueueIterator::new(flash, flash_range),
     }
@@ -280,7 +277,7 @@ impl<'d, S: NorFlash> PeekIterator<'d, S> {
     }
 }
 
-/// An iterator-like interface for peeking into events stored in flash.
+/// An iterator-like interface for peeking into data stored in flash.
 struct QueueIterator<'d, S: NorFlash> {
     flash: &'d mut S,
     flash_range: Range<u32>,
@@ -604,11 +601,11 @@ mod tests {
                 );
             }
 
-            let mut poper = pop_many(&mut flash, flash_range.clone());
+            let mut popper = pop_many(&mut flash, flash_range.clone());
             for i in 0..5 {
                 let data = vec![i as u8; 50];
                 assert_eq!(
-                    &poper.next(&mut data_buffer).unwrap().unwrap()[..],
+                    &popper.next(&mut data_buffer).unwrap().unwrap()[..],
                     &data,
                     "At {i}"
                 );
@@ -629,11 +626,11 @@ mod tests {
                 );
             }
 
-            let mut poper = pop_many(&mut flash, flash_range.clone());
+            let mut popper = pop_many(&mut flash, flash_range.clone());
             for i in 5..25 {
                 let data = vec![i as u8; 50];
                 assert_eq!(
-                    &poper.next(&mut data_buffer).unwrap().unwrap()[..],
+                    &popper.next(&mut data_buffer).unwrap().unwrap()[..],
                     &data,
                     "At {i}"
                 );

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -604,12 +604,11 @@ mod tests {
                 );
             }
 
+            let mut poper = pop_many(&mut flash, flash_range.clone());
             for i in 0..5 {
                 let data = vec![i as u8; 50];
                 assert_eq!(
-                    &pop(&mut flash, flash_range.clone(), &mut data_buffer)
-                        .unwrap()
-                        .unwrap()[..],
+                    &poper.next(&mut data_buffer).unwrap().unwrap()[..],
                     &data,
                     "At {i}"
                 );
@@ -630,12 +629,11 @@ mod tests {
                 );
             }
 
+            let mut poper = pop_many(&mut flash, flash_range.clone());
             for i in 5..25 {
                 let data = vec![i as u8; 50];
                 assert_eq!(
-                    &pop(&mut flash, flash_range.clone(), &mut data_buffer)
-                        .unwrap()
-                        .unwrap()[..],
+                    &poper.next(&mut data_buffer).unwrap().unwrap()[..],
                     &data,
                     "At {i}"
                 );

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -231,9 +231,9 @@ pub struct PopIterator<'d, S: MultiwriteNorFlash> {
 }
 
 impl<'d, S: MultiwriteNorFlash> PopIterator<'d, S> {
-    /// Pop the next event.
+    /// Pop the next data.
     ///
-    /// The data is written to the given `data_buffer`` and the part that was written is returned.
+    /// The data is written to the given `data_buffer` and the part that was written is returned.
     /// It is valid to only use the length of the returned slice and use the original `data_buffer`.
     /// The `data_buffer` may contain extra data on ranges after the returned slice.
     /// You should not depend on that data.
@@ -261,9 +261,9 @@ pub struct PeekIterator<'d, S: NorFlash> {
 }
 
 impl<'d, S: NorFlash> PeekIterator<'d, S> {
-    /// Peek at the next event.
+    /// Peek at the next data.
     ///
-    /// The data is written to the given `data_buffer`` and the part that was written is returned.
+    /// The data is written to the given `data_buffer` and the part that was written is returned.
     /// It is valid to only use the length of the returned slice and use the original `data_buffer`.
     /// The `data_buffer` may contain extra data on ranges after the returned slice.
     /// You should not depend on that data.
@@ -281,7 +281,7 @@ impl<'d, S: NorFlash> PeekIterator<'d, S> {
 }
 
 /// An iterator-like interface for peeking into events stored in flash.
-pub struct QueueIterator<'d, S: NorFlash> {
+struct QueueIterator<'d, S: NorFlash> {
     flash: &'d mut S,
     flash_range: Range<u32>,
     oldest_page: Option<usize>,

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -82,6 +82,7 @@ pub fn push<S: NorFlash>(
     }
 
     let current_page = find_youngest_page(flash, flash_range.clone())?;
+
     let page_data_start_address =
         calculate_page_address::<S>(flash_range.clone(), current_page) + S::WORD_SIZE as u32;
     let page_data_end_address =

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -561,7 +561,7 @@ mod tests {
         let flash_range = 0x000..0x1000;
         let mut data_buffer = [0; 1024];
 
-        for a in 0..100 {
+        for _ in 0..100 {
             for i in 0..20 {
                 let data = vec![i as u8; 50];
                 push(&mut flash, flash_range.clone(), &data, false).unwrap();


### PR DESCRIPTION
Supporting peek_many and pop_many is needed for situations where you want to batch multiple events in a request to some other location, but don't want to clear them from the queue until you're sure the request got complete successfully.

I've started working on an implementation of this functionality, but I'd like to get your opinion first on what the API should look like. Obviously I'd need to add more tests and docs here, just want to get your opinion on this first.

I've basically got three versions, where the first version is in this PR:

```
pub fn peek_many<'d, S: NorFlash, const N: usize>(
    flash: &mut S,
    flash_range: Range<u32>,
    data_buffer: &'d mut [u8],
    output_buffer: &mut [MaybeUninit<&'d mut [u8]>; N],
) -> Result<usize, Error<S::Error>> {
```

vs.

```
pub fn peek_many<'d, S: NorFlash, const N: usize>(
    flash: &mut S,
    flash_range: Range<u32>,
    data_buffer: &'d mut [u8],
    output_buffer: &mut Vec<&'d mut [u8], N>) -> Result<(), Error<S::Error>>
```

vs.

```
pub fn peek_many<'d, S: NorFlash, const N: usize>(
    flash: &mut S,
    flash_range: Range<u32>,
    data_buffer: &'d mut [u8],
) -> Result<Vec<&'d mut [u8], N>, Error<S::Error>> {
```

Maybe there are other alternatives that you think could work.

The advantage of the first one is that we can avoid the heapless dependency, at no big cost API-wise, since you'd generally need to pre-alloc the size of the heapless vec anyway.

The API for pop_many would be extended in a similar way.
