### PR TITLE
Async support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ futures = { version = "0.3.30", features = ["executor"], optional = true }
 [dev-dependencies]
 approx = "0.5.1"
 futures = { version = "0.3.30", features = ["executor"] }
+futures-test = "0.3.30"
 
 [features]
 defmt = ["dep:defmt"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,14 @@ keywords = ["no_std", "embedded", "flash", "storage"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-embedded-storage = "0.3.0"
+embedded-storage-async = "0.4.1"
 defmt = { version = "0.3", optional = true }
+futures = { version = "0.3.30", features = ["executor"], optional = true }
 
 [dev-dependencies]
 approx = "0.5.1"
+futures = { version = "0.3.30", features = ["executor"] }
 
 [features]
 defmt = ["dep:defmt"]
-_test = []
+_test = ["futures"]

--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ When using peek_many, you can look at all data from oldest to newest.
   aid with shutdown/cancellation issues.
 - When the state is corrupted, many issues can now be repaired with the repair functions in the map and queue modules
 - Made changes to the entire to better survive shutoffs
+- *Breaking* Convert API to async first supporting the traits from embedded-storage-async. Flash
+  drivers supporting `sequential-storage` can be wrapped using
+  [BlockingAsync](https://docs.embassy.dev/embassy-embedded-hal/git/default/adapter/struct.BlockingAsync.html), and a 
+  simple [blocking executor](https://docs.rs/futures/0.3.30/futures/executor/fn.block_on.html) can be used to call the 
+  API from a non-async function.
 
 ### 0.6.2 - 22-12-23
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,6 +13,7 @@ sequential-storage = { path = "..", features = ["_test"] }
 arbitrary = { version = "1.2.2", features = ["derive"] }
 rand = "0.8.5"
 rand_pcg = "0.3.1"
+futures = { version = "0.3.30", features = ["executor"] }
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/src/item.rs
+++ b/src/item.rs
@@ -141,16 +141,16 @@ impl ItemHeader {
     async fn write<S: NorFlash>(&self, flash: &mut S, address: u32) -> Result<(), Error<S::Error>> {
         let mut buffer = AlignedBuf([0xFF; MAX_WORD_SIZE]);
 
-        buffer.0[Self::DATA_CRC_FIELD]
+        buffer[Self::DATA_CRC_FIELD]
             .copy_from_slice(&self.crc.map(|crc| crc.get()).unwrap_or(0).to_le_bytes());
-        buffer.0[Self::LENGTH_FIELD].copy_from_slice(&self.length.to_le_bytes());
-        buffer.0[Self::LENGTH_CRC_FIELD]
+        buffer[Self::LENGTH_FIELD].copy_from_slice(&self.length.to_le_bytes());
+        buffer[Self::LENGTH_CRC_FIELD]
             .copy_from_slice(&crc16(&self.length.to_le_bytes()).to_le_bytes());
 
         flash
             .write(
                 address,
-                &buffer.0[..round_up_to_alignment_usize::<S>(Self::LENGTH)],
+                &buffer[..round_up_to_alignment_usize::<S>(Self::LENGTH)],
             )
             .await
             .map_err(|e| Error::Storage {
@@ -241,11 +241,11 @@ impl<'d> Item<'d> {
 
         if !data_left.is_empty() {
             let mut buffer = AlignedBuf([0; MAX_WORD_SIZE]);
-            buffer.0[..data_left.len()].copy_from_slice(data_left);
+            buffer[..data_left.len()].copy_from_slice(data_left);
             flash
                 .write(
                     data_address + data_block.len() as u32,
-                    &buffer.0[..round_up_to_alignment_usize::<S>(data_left.len())],
+                    &buffer[..round_up_to_alignment_usize::<S>(data_left.len())],
                 )
                 .await
                 .map_err(|e| Error::Storage {

--- a/src/item.rs
+++ b/src/item.rs
@@ -510,10 +510,6 @@ impl ItemHeaderIter {
         flash: &mut S,
         callback: impl Fn(&ItemHeader, u32) -> ControlFlow<(), ()>,
     ) -> Result<(Option<ItemHeader>, u32), Error<S::Error>> {
-        if self.current_address >= self.end_address {
-            return Ok((None, self.current_address));
-        }
-
         loop {
             match ItemHeader::read_new(flash, self.current_address, self.end_address).await {
                 Ok(Some(header)) => {

--- a/src/item.rs
+++ b/src/item.rs
@@ -288,8 +288,9 @@ pub async fn find_next_free_item_spot<S: NorFlash>(
     end_address: u32,
     data_length: u32,
 ) -> Result<Option<u32>, Error<S::Error>> {
-    let mut it = HeaderIter::new(start_address, end_address);
-    let (_, free_item_address) = it.traverse(flash, |_, _| ControlFlow::Continue(())).await?;
+    let (_, free_item_address) = HeaderIter::new(start_address, end_address)
+        .traverse(flash, |_, _| ControlFlow::Continue(()))
+        .await?;
     if let Some(available) = ItemHeader::available_data_bytes::<S>(end_address - free_item_address)
     {
         if available >= data_length {

--- a/src/item.rs
+++ b/src/item.rs
@@ -530,12 +530,7 @@ impl ItemHeaderIter {
                     return Ok((None, self.current_address));
                 }
                 Err(Error::Corrupted { .. }) => {
-                    #[cfg(feature = "defmt")]
-                    defmt::error!(
-                        "Found a corrupted item header at {:X}. Skipping...",
-                        self.current_address
-                    );
-                    self.current_address += S::WORD_SIZE as u32;
+                    self.current_address = ItemHeader::data_address::<S>(self.current_address);
                 }
                 Err(e) => return Err(e),
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 
 use core::{
     fmt::Debug,
-    ops::{ControlFlow, Deref, DerefMut, Range},
+    ops::{Deref, DerefMut, Range},
 };
 use embedded_storage_async::nor_flash::NorFlash;
 
@@ -375,24 +375,6 @@ impl<S: NorFlash> NorFlashExt for S {
     } else {
         Self::READ_SIZE
     };
-}
-
-/// Some plumbing for things not yet stable in std/core
-trait ResultToControlflow<B, C> {
-    fn to_controlflow(self) -> ControlFlow<B, C>;
-}
-
-impl<B, C, E> ResultToControlflow<B, C> for Result<C, E>
-where
-    // T: Into<C>,
-    E: Into<B>,
-{
-    fn to_controlflow(self) -> ControlFlow<B, C> {
-        match self {
-            Ok(c) => ControlFlow::Continue(c),
-            Err(b) => ControlFlow::Break(b.into()),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,22 +398,22 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::executor::block_on;
+    use futures_test::test;
 
     type MockFlash = mock_flash::MockFlashBase<4, 4, 64>;
 
-    fn write_aligned(
+    async fn write_aligned(
         flash: &mut MockFlash,
         offset: u32,
         bytes: &[u8],
     ) -> Result<(), mock_flash::MockFlashError> {
         let mut buf = AlignedBuf([0; 256]);
         buf[..bytes.len()].copy_from_slice(bytes);
-        block_on(flash.write(offset, &buf[..bytes.len()]))
+        flash.write(offset, &buf[..bytes.len()]).await
     }
 
     #[test]
-    fn test_find_pages() {
+    async fn test_find_pages() {
         // Page setup:
         // 0: closed
         // 1: closed
@@ -422,123 +422,89 @@ mod tests {
 
         let mut flash = MockFlash::default();
         // Page 0 markers
-        write_aligned(&mut flash, 0x000, &[MARKER, 0, 0, 0]).unwrap();
-        write_aligned(&mut flash, 0x100 - 4, &[0, 0, 0, MARKER]).unwrap();
+        write_aligned(&mut flash, 0x000, &[MARKER, 0, 0, 0])
+            .await
+            .unwrap();
+        write_aligned(&mut flash, 0x100 - 4, &[0, 0, 0, MARKER])
+            .await
+            .unwrap();
         // Page 1 markers
-        write_aligned(&mut flash, 0x100, &[MARKER, 0, 0, 0]).unwrap();
-        write_aligned(&mut flash, 0x200 - 4, &[0, 0, 0, MARKER]).unwrap();
+        write_aligned(&mut flash, 0x100, &[MARKER, 0, 0, 0])
+            .await
+            .unwrap();
+        write_aligned(&mut flash, 0x200 - 4, &[0, 0, 0, MARKER])
+            .await
+            .unwrap();
         // Page 2 markers
-        write_aligned(&mut flash, 0x200, &[MARKER, 0, 0, 0]).unwrap();
+        write_aligned(&mut flash, 0x200, &[MARKER, 0, 0, 0])
+            .await
+            .unwrap();
 
         assert_eq!(
-            block_on(find_first_page(
-                &mut flash,
-                0x000..0x400,
-                0,
-                PageState::Open
-            ))
-            .unwrap(),
+            find_first_page(&mut flash, 0x000..0x400, 0, PageState::Open)
+                .await
+                .unwrap(),
             Some(3)
         );
         assert_eq!(
-            block_on(find_first_page(
-                &mut flash,
-                0x000..0x400,
-                0,
-                PageState::PartialOpen
-            ))
-            .unwrap(),
+            find_first_page(&mut flash, 0x000..0x400, 0, PageState::PartialOpen)
+                .await
+                .unwrap(),
             Some(2)
         );
         assert_eq!(
-            block_on(find_first_page(
-                &mut flash,
-                0x000..0x400,
-                1,
-                PageState::PartialOpen
-            ))
-            .unwrap(),
+            find_first_page(&mut flash, 0x000..0x400, 1, PageState::PartialOpen)
+                .await
+                .unwrap(),
             Some(2)
         );
         assert_eq!(
-            block_on(find_first_page(
-                &mut flash,
-                0x000..0x400,
-                2,
-                PageState::PartialOpen
-            ))
-            .unwrap(),
+            find_first_page(&mut flash, 0x000..0x400, 2, PageState::PartialOpen)
+                .await
+                .unwrap(),
             Some(2)
         );
         assert_eq!(
-            block_on(find_first_page(
-                &mut flash,
-                0x000..0x400,
-                3,
-                PageState::Open
-            ))
-            .unwrap(),
+            find_first_page(&mut flash, 0x000..0x400, 3, PageState::Open)
+                .await
+                .unwrap(),
             Some(3)
         );
         assert_eq!(
-            block_on(find_first_page(
-                &mut flash,
-                0x000..0x200,
-                0,
-                PageState::PartialOpen
-            ))
-            .unwrap(),
+            find_first_page(&mut flash, 0x000..0x200, 0, PageState::PartialOpen)
+                .await
+                .unwrap(),
             None
         );
 
         assert_eq!(
-            block_on(find_first_page(
-                &mut flash,
-                0x000..0x400,
-                0,
-                PageState::Closed
-            ))
-            .unwrap(),
+            find_first_page(&mut flash, 0x000..0x400, 0, PageState::Closed)
+                .await
+                .unwrap(),
             Some(0)
         );
         assert_eq!(
-            block_on(find_first_page(
-                &mut flash,
-                0x000..0x400,
-                1,
-                PageState::Closed
-            ))
-            .unwrap(),
+            find_first_page(&mut flash, 0x000..0x400, 1, PageState::Closed)
+                .await
+                .unwrap(),
             Some(1)
         );
         assert_eq!(
-            block_on(find_first_page(
-                &mut flash,
-                0x000..0x400,
-                2,
-                PageState::Closed
-            ))
-            .unwrap(),
+            find_first_page(&mut flash, 0x000..0x400, 2, PageState::Closed)
+                .await
+                .unwrap(),
             Some(0)
         );
         assert_eq!(
-            block_on(find_first_page(
-                &mut flash,
-                0x000..0x400,
-                3,
-                PageState::Closed
-            ))
-            .unwrap(),
+            find_first_page(&mut flash, 0x000..0x400, 3, PageState::Closed)
+                .await
+                .unwrap(),
             Some(0)
         );
         assert_eq!(
-            block_on(find_first_page(
-                &mut flash,
-                0x200..0x400,
-                0,
-                PageState::Closed
-            ))
-            .unwrap(),
+            find_first_page(&mut flash, 0x200..0x400, 0, PageState::Closed)
+                .await
+                .unwrap(),
             None
         );
     }

--- a/src/map.rs
+++ b/src/map.rs
@@ -68,7 +68,8 @@
 //! let flash_range = 0x1000..0x3000;
 //! // We need to give the crate a buffer to work with.
 //! // It must be big enough to serialize the biggest value of your storage type in,
-//! // rounded up to to word alignment of the flash.
+//! // rounded up to to word alignment of the flash. Some kinds of flash may require
+//! // this buffer to be aligned in RAM as well.
 //! let mut data_buffer = [0; 100];
 //!
 //! // We can fetch an item from the flash.
@@ -397,7 +398,7 @@ pub async fn store_item<I: StorageItem, S: NorFlash>(
             }
         }
 
-        // If we get here, we just freshly partially closed a new page, so this should succeed
+        // If we get here, we just freshly partially closed a new page, so the next loop iteration should succeed.
         recursion_level += 1;
     }
 }
@@ -704,7 +705,7 @@ mod tests {
         let mut flash = MockFlashBig::default();
         let flash_range = 0x000..0x1000;
 
-        let mut data_buffer = [0; 128];
+        let mut data_buffer = AlignedBuf([0; 128]);
 
         let item =
             fetch_item::<MockStorageItem, _>(&mut flash, flash_range.clone(), &mut data_buffer, 0)
@@ -854,7 +855,7 @@ mod tests {
         const UPPER_BOUND: u8 = 2;
 
         let mut tiny_flash = MockFlashTiny::default();
-        let mut data_buffer = [0; 128];
+        let mut data_buffer = AlignedBuf([0; 128]);
 
         for i in 0..UPPER_BOUND {
             let item = MockStorageItem {
@@ -904,7 +905,7 @@ mod tests {
         const UPPER_BOUND: u8 = 67;
 
         let mut big_flash = MockFlashBig::default();
-        let mut data_buffer = [0; 128];
+        let mut data_buffer = AlignedBuf([0; 128]);
 
         for i in 0..UPPER_BOUND {
             let item = MockStorageItem {
@@ -952,7 +953,7 @@ mod tests {
     #[test]
     async fn store_many_items_big() {
         let mut flash = mock_flash::MockFlashBase::<4, 1, 4096>::default();
-        let mut data_buffer = [0; 128];
+        let mut data_buffer = AlignedBuf([0; 128]);
 
         const LENGHT_PER_KEY: [usize; 24] = [
             11, 13, 6, 13, 13, 10, 2, 3, 5, 36, 1, 65, 4, 6, 1, 15, 10, 7, 3, 15, 9, 3, 4, 5,

--- a/src/mock_flash.rs
+++ b/src/mock_flash.rs
@@ -137,7 +137,7 @@ impl<const PAGES: usize, const BYTES_PER_WORD: usize, const PAGE_WORDS: usize>
                 crate::calculate_page_end_address::<Self>(Self::FULL_FLASH_RANGE, page_index)
                     - Self::WORD_SIZE as u32;
 
-            let mut it = crate::item::HeaderIter::new(page_data_start, page_data_end);
+            let mut it = crate::item::ItemHeaderIter::new(page_data_start, page_data_end);
             while let (Some(header), item_address) =
                 block_on(it.traverse(self, |_, _| core::ops::ControlFlow::Break(()))).unwrap()
             {
@@ -185,7 +185,7 @@ impl<const PAGES: usize, const BYTES_PER_WORD: usize, const PAGE_WORDS: usize>
                 - Self::WORD_SIZE as u32;
 
         let mut found_item = None;
-        let mut it = crate::item::HeaderIter::new(page_data_start, page_data_end);
+        let mut it = crate::item::ItemHeaderIter::new(page_data_start, page_data_end);
         while let (Some(header), item_address) =
             block_on(it.traverse(self, |_, _| ControlFlow::Break(()))).unwrap()
         {

--- a/src/mock_flash.rs
+++ b/src/mock_flash.rs
@@ -139,7 +139,7 @@ impl<const PAGES: usize, const BYTES_PER_WORD: usize, const PAGE_WORDS: usize>
 
             let mut it = crate::item::ItemHeaderIter::new(page_data_start, page_data_end);
             while let (Some(header), item_address) =
-                block_on(it.traverse(self, |_, _| core::ops::ControlFlow::Break(()))).unwrap()
+                block_on(it.traverse(self, |_, _| false)).unwrap()
             {
                 let next_item_address = header.next_item_address::<Self>(item_address);
                 let maybe_item =
@@ -163,8 +163,6 @@ impl<const PAGES: usize, const BYTES_PER_WORD: usize, const PAGE_WORDS: usize>
     /// - If true, the item is present and fine.
     /// - If false, the item is corrupt or erased.
     pub fn get_item_presence(&mut self, target_item_address: u32) -> Option<bool> {
-        use core::ops::ControlFlow;
-
         use crate::NorFlashExt;
         use futures::executor::block_on;
 
@@ -186,8 +184,7 @@ impl<const PAGES: usize, const BYTES_PER_WORD: usize, const PAGE_WORDS: usize>
 
         let mut found_item = None;
         let mut it = crate::item::ItemHeaderIter::new(page_data_start, page_data_end);
-        while let (Some(header), item_address) =
-            block_on(it.traverse(self, |_, _| ControlFlow::Break(()))).unwrap()
+        while let (Some(header), item_address) = block_on(it.traverse(self, |_, _| false)).unwrap()
         {
             let next_item_address = header.next_item_address::<Self>(item_address);
 

--- a/src/mock_flash.rs
+++ b/src/mock_flash.rs
@@ -288,8 +288,10 @@ impl<const PAGES: usize, const BYTES_PER_WORD: usize, const PAGE_WORDS: usize> N
 
         let range = Self::validate_operation(offset, bytes.len())?;
 
-        if bytes.as_ptr() as usize % Self::WRITE_SIZE != 0 {
-            panic!("write buffer must be aligned to Self::WRITE_SIZE bytes");
+        // Check alignment. Some flash types are strict about the alignment of the input buffer. This ensures
+        // that the mock flash is also strict to catch bugs and avoid regressions.
+        if bytes.as_ptr() as usize % 4 != 0 {
+            panic!("write buffer must be aligned to 4 bytes");
         }
 
         if bytes.len() % Self::WRITE_SIZE != 0 {

--- a/src/mock_flash.rs
+++ b/src/mock_flash.rs
@@ -102,19 +102,6 @@ impl<const PAGES: usize, const BYTES_PER_WORD: usize, const PAGE_WORDS: usize>
         }
     }
 
-    pub(crate) async fn write_aligned<const SIZE: usize>(
-        &mut self,
-        offset: u32,
-        bytes: &[u8],
-    ) -> Result<(), MockFlashError> {
-        #[repr(align(4))]
-        struct AlignedBuf<const SIZE: usize>([u8; SIZE]);
-
-        let mut buf = AlignedBuf([0; SIZE]);
-        buf.0[..bytes.len()].copy_from_slice(bytes);
-        self.write(offset, &buf.0[..bytes.len()]).await
-    }
-
     #[cfg(feature = "_test")]
     /// Print all items in flash to the returned string
     pub fn print_items(&mut self) -> String {

--- a/src/mock_flash.rs
+++ b/src/mock_flash.rs
@@ -197,7 +197,8 @@ impl<const PAGES: usize, const BYTES_PER_WORD: usize, const PAGE_WORDS: usize>
                         .unwrap();
 
                 match maybe_item {
-                    crate::item::MaybeItem::Corrupted(_, _) | crate::item::MaybeItem::Erased(_) => {
+                    crate::item::MaybeItem::Corrupted(_, _)
+                    | crate::item::MaybeItem::Erased(_, _) => {
                         found_item.replace(false);
                         break;
                     }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -687,7 +687,7 @@ mod tests {
         let flash_range = 0x00..0x40;
         let mut data_buffer = [0; 1024];
 
-        for i in 0..1 {
+        for i in 0..2000 {
             println!("{i}");
             let data = vec![i as u8; i % 20 + 1];
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -5,6 +5,7 @@
 //! ```rust
 //! # use sequential_storage::queue::{push, peek, pop};
 //! # use mock_flash::MockFlashBase;
+//! # use futures::executor::block_on;
 //! # type Flash = MockFlashBase<10, 1, 4096>;
 //! # mod mock_flash {
 //! #   include!("mock_flash.rs");
@@ -26,35 +27,34 @@
 //! let my_data = [10, 47, 29];
 //!
 //! // We can push some data to the queue
-//!
-//! push(&mut flash, flash_range.clone(), &my_data, false).unwrap();
+//! block_on(push(&mut flash, flash_range.clone(), &my_data, false)).unwrap();
 //!
 //! // We can peek at the oldest data
 //!
 //! assert_eq!(
-//!     &peek(&mut flash, flash_range.clone(), &mut data_buffer).unwrap().unwrap()[..],
+//!     &block_on(peek(&mut flash, flash_range.clone(), &mut data_buffer)).unwrap().unwrap()[..],
 //!     &my_data[..]
 //! );
 //!
 //! // With popping we get back the oldest data, but that data is now also removed
 //!
 //! assert_eq!(
-//!     &pop(&mut flash, flash_range.clone(), &mut data_buffer).unwrap().unwrap()[..],
+//!     &block_on(pop(&mut flash, flash_range.clone(), &mut data_buffer)).unwrap().unwrap()[..],
 //!     &my_data[..]
 //! );
 //!
 //! // If we pop again, we find there's no data anymore
 //!
 //! assert_eq!(
-//!     pop(&mut flash, flash_range.clone(), &mut data_buffer),
+//!     block_on(pop(&mut flash, flash_range.clone(), &mut data_buffer)),
 //!     Ok(None)
 //! );
 //! ```
 
-use crate::item::{find_next_free_item_spot, is_page_empty, read_item_headers, Item, ItemHeader};
+use crate::item::{find_next_free_item_spot, is_page_empty, HeaderIter, Item, ItemHeader};
 
 use super::*;
-use embedded_storage::nor_flash::MultiwriteNorFlash;
+use embedded_storage_async::nor_flash::MultiwriteNorFlash;
 
 /// Push data into the queue in the given flash memory with the given range.
 /// The data can only be taken out with the [pop] function.
@@ -64,7 +64,7 @@ use embedded_storage::nor_flash::MultiwriteNorFlash;
 ///
 /// *Note: If a page is already used and you push more data than the remaining capacity of the page,
 /// the entire remaining capacity will go unused because the data is stored on the next page.*
-pub fn push<S: NorFlash>(
+pub async fn push<S: NorFlash>(
     flash: &mut S,
     flash_range: Range<u32>,
     data: &[u8],
@@ -84,14 +84,14 @@ pub fn push<S: NorFlash>(
         return Err(Error::BufferTooBig);
     }
 
-    let current_page = find_youngest_page(flash, flash_range.clone())?;
+    let current_page = find_youngest_page(flash, flash_range.clone()).await?;
 
     let page_data_start_address =
         calculate_page_address::<S>(flash_range.clone(), current_page) + S::WORD_SIZE as u32;
     let page_data_end_address =
         calculate_page_end_address::<S>(flash_range.clone(), current_page) - S::WORD_SIZE as u32;
 
-    partial_close_page(flash, flash_range.clone(), current_page)?;
+    partial_close_page(flash, flash_range.clone(), current_page).await?;
 
     // Find the last item on the page so we know where we need to write
 
@@ -100,15 +100,16 @@ pub fn push<S: NorFlash>(
         page_data_start_address,
         page_data_end_address,
         data.len() as u32,
-    )?;
+    )
+    .await?;
 
     if next_address.is_none() {
         // No cap left on this page, move to the next page
         let next_page = next_page::<S>(flash_range.clone(), current_page);
-        match get_page_state(flash, flash_range.clone(), next_page)? {
+        match get_page_state(flash, flash_range.clone(), next_page).await? {
             PageState::Open => {
-                close_page(flash, flash_range.clone(), current_page)?;
-                partial_close_page(flash, flash_range.clone(), next_page)?;
+                close_page(flash, flash_range.clone(), current_page).await?;
+                partial_close_page(flash, flash_range.clone(), next_page).await?;
                 next_address = Some(
                     calculate_page_address::<S>(flash_range.clone(), next_page)
                         + S::WORD_SIZE as u32,
@@ -120,7 +121,7 @@ pub fn push<S: NorFlash>(
                         + S::WORD_SIZE as u32;
 
                 if !allow_overwrite_old_data
-                    && !is_page_empty(flash, flash_range.clone(), next_page, Some(state))?
+                    && !is_page_empty(flash, flash_range.clone(), next_page, Some(state)).await?
                 {
                     return Err(Error::FullStorage);
                 }
@@ -130,14 +131,15 @@ pub fn push<S: NorFlash>(
                         calculate_page_address::<S>(flash_range.clone(), next_page),
                         calculate_page_end_address::<S>(flash_range.clone(), next_page),
                     )
+                    .await
                     .map_err(|e| Error::Storage {
                         value: e,
                         #[cfg(feature = "_test")]
                         backtrace: std::backtrace::Backtrace::capture(),
                     })?;
 
-                close_page(flash, flash_range.clone(), current_page)?;
-                partial_close_page(flash, flash_range.clone(), next_page)?;
+                close_page(flash, flash_range.clone(), current_page).await?;
+                partial_close_page(flash, flash_range.clone(), next_page).await?;
                 next_address = Some(next_page_data_start_address);
             }
             PageState::PartialOpen => {
@@ -152,7 +154,7 @@ pub fn push<S: NorFlash>(
         }
     }
 
-    Item::write_new(flash, next_address.unwrap(), data)?;
+    Item::write_new(flash, next_address.unwrap(), data).await?;
 
     Ok(())
 }
@@ -162,12 +164,12 @@ pub fn push<S: NorFlash>(
 /// If you also want to remove the data use [pop_many].
 ///
 /// Returns an iterator-like type that can be used to peek into the data.
-pub fn peek_many<S: NorFlash>(
+pub async fn peek_many<S: NorFlash>(
     flash: &mut S,
     flash_range: Range<u32>,
 ) -> Result<PeekIterator<'_, S>, Error<S::Error>> {
     Ok(PeekIterator {
-        iter: QueueIterator::new(flash, flash_range)?,
+        iter: QueueIterator::new(flash, flash_range).await?,
     })
 }
 
@@ -181,12 +183,12 @@ pub fn peek_many<S: NorFlash>(
 /// You should not depend on that data.
 ///
 /// If the data buffer is not big enough an error is returned.
-pub fn peek<'d, S: NorFlash>(
+pub async fn peek<'d, S: NorFlash>(
     flash: &mut S,
     flash_range: Range<u32>,
     data_buffer: &'d mut [u8],
 ) -> Result<Option<&'d mut [u8]>, Error<S::Error>> {
-    peek_many(flash, flash_range)?.next(data_buffer)
+    peek_many(flash, flash_range).await?.next(data_buffer).await
 }
 
 /// Pop the data from oldest to newest.
@@ -194,12 +196,12 @@ pub fn peek<'d, S: NorFlash>(
 /// If you don't want to remove the data use [peek_many].
 ///
 /// Returns an iterator-like type that can be used to pop the data.
-pub fn pop_many<S: MultiwriteNorFlash>(
+pub async fn pop_many<S: MultiwriteNorFlash>(
     flash: &mut S,
     flash_range: Range<u32>,
 ) -> Result<PopIterator<'_, S>, Error<S::Error>> {
     Ok(PopIterator {
-        iter: QueueIterator::new(flash, flash_range)?,
+        iter: QueueIterator::new(flash, flash_range).await?,
     })
 }
 
@@ -213,12 +215,12 @@ pub fn pop_many<S: MultiwriteNorFlash>(
 /// You should not depend on that data.
 ///
 /// If the data buffer is not big enough an error is returned.
-pub fn pop<'d, S: MultiwriteNorFlash>(
+pub async fn pop<'d, S: MultiwriteNorFlash>(
     flash: &mut S,
     flash_range: Range<u32>,
     data_buffer: &'d mut [u8],
 ) -> Result<Option<&'d mut [u8]>, Error<S::Error>> {
-    pop_many(flash, flash_range)?.next(data_buffer)
+    pop_many(flash, flash_range).await?.next(data_buffer).await
 }
 
 /// Iterator for pop'ing elements in the queue.
@@ -236,17 +238,17 @@ impl<'d, S: MultiwriteNorFlash> PopIterator<'d, S> {
     /// You should not depend on that data.
     ///
     /// If the data buffer is not big enough an error is returned.
-    pub fn next<'m>(
+    pub async fn next<'m>(
         &mut self,
         data_buffer: &'m mut [u8],
     ) -> Result<Option<&'m mut [u8]>, Error<S::Error>> {
         let reset_point = self.iter.create_reset_point();
 
-        if let Some((item, item_address)) = self.iter.next(data_buffer)? {
+        if let Some((item, item_address)) = self.iter.next(data_buffer).await? {
             let (header, data_buffer) = item.destruct();
             let ret = &mut data_buffer[..header.length as usize];
 
-            match header.erase_data(self.iter.flash, item_address) {
+            match header.erase_data(self.iter.flash, item_address).await {
                 Ok(_) => Ok(Some(ret)),
                 Err(e) => {
                     self.iter.recover_from_reset_point(reset_point);
@@ -274,11 +276,11 @@ impl<'d, S: NorFlash> PeekIterator<'d, S> {
     /// You should not depend on that data.
     ///
     /// If the data buffer is not big enough an error is returned.
-    pub fn next<'m>(
+    pub async fn next<'m>(
         &mut self,
         data_buffer: &'m mut [u8],
     ) -> Result<Option<&'m mut [u8]>, Error<S::Error>> {
-        Ok(self.iter.next(data_buffer)?.map(|(item, _)| {
+        Ok(self.iter.next(data_buffer).await?.map(|(item, _)| {
             let (header, data_buffer) = item.destruct();
             &mut data_buffer[..header.length as usize]
         }))
@@ -307,7 +309,7 @@ enum CurrentAddress {
 }
 
 impl<'d, S: NorFlash> QueueIterator<'d, S> {
-    fn new(flash: &'d mut S, flash_range: Range<u32>) -> Result<Self, Error<S::Error>> {
+    async fn new(flash: &'d mut S, flash_range: Range<u32>) -> Result<Self, Error<S::Error>> {
         assert_eq!(flash_range.start % S::ERASE_SIZE as u32, 0);
         assert_eq!(flash_range.end % S::ERASE_SIZE as u32, 0);
 
@@ -317,7 +319,7 @@ impl<'d, S: NorFlash> QueueIterator<'d, S> {
         // We start at the start of the oldest page
         let current_address = calculate_page_address::<S>(
             flash_range.clone(),
-            find_oldest_page(flash, flash_range.clone())?,
+            find_oldest_page(flash, flash_range.clone()).await?,
         ) + S::WORD_SIZE as u32;
 
         Ok(Self {
@@ -327,7 +329,7 @@ impl<'d, S: NorFlash> QueueIterator<'d, S> {
         })
     }
 
-    fn next<'m>(
+    async fn next<'m>(
         &mut self,
         data_buffer: &'m mut [u8],
     ) -> Result<Option<(Item<'m>, u32)>, Error<S::Error>> {
@@ -338,8 +340,11 @@ impl<'d, S: NorFlash> QueueIterator<'d, S> {
             let (current_page, current_address) = match self.current_address {
                 CurrentAddress::PageAfter(previous_page) => {
                     let next_page = next_page::<S>(self.flash_range.clone(), previous_page);
-                    if get_page_state(self.flash, self.flash_range.clone(), next_page)?.is_open()
-                        || next_page == find_oldest_page(self.flash, self.flash_range.clone())?
+                    if get_page_state(self.flash, self.flash_range.clone(), next_page)
+                        .await?
+                        .is_open()
+                        || next_page
+                            == find_oldest_page(self.flash, self.flash_range.clone()).await?
                     {
                         return Ok(None);
                     }
@@ -363,50 +368,55 @@ impl<'d, S: NorFlash> QueueIterator<'d, S> {
                     - S::WORD_SIZE as u32;
 
             // Search for the first item with data
-            if let (Some((found_item_header, found_item_address)), _) = read_item_headers(
-                self.flash,
-                current_address,
-                page_data_end_address,
-                |_, item_header, item_address| {
-                    if item_header.crc.is_some() {
-                        ControlFlow::Break((item_header, item_address))
-                    } else {
-                        ControlFlow::Continue(())
-                    }
-                },
-            )? {
-                let maybe_item = found_item_header.read_item(
-                    self.flash,
-                    data_buffer.take().unwrap(),
-                    found_item_address,
-                    page_data_end_address,
-                )?;
+            let mut it = HeaderIter::new(current_address, page_data_end_address);
+            loop {
+                if let (Some(found_item_header), found_item_address) = it
+                    .traverse(self.flash, |header, _| {
+                        if header.crc.is_some() {
+                            ControlFlow::Break(())
+                        } else {
+                            ControlFlow::Continue(())
+                        }
+                    })
+                    .await?
+                {
+                    let maybe_item = found_item_header
+                        .read_item(
+                            self.flash,
+                            data_buffer.take().unwrap(),
+                            found_item_address,
+                            page_data_end_address,
+                        )
+                        .await?;
 
-                match maybe_item {
-                    item::MaybeItem::Corrupted(header, db) => {
-                        let next_address = header.next_item_address::<S>(found_item_address);
-                        self.current_address = if next_address >= page_data_end_address {
-                            CurrentAddress::PageAfter(current_page)
-                        } else {
-                            CurrentAddress::Address(next_address)
-                        };
-                        data_buffer.replace(db);
-                        continue;
+                    match maybe_item {
+                        item::MaybeItem::Corrupted(header, db) => {
+                            let next_address = header.next_item_address::<S>(found_item_address);
+                            self.current_address = if next_address >= page_data_end_address {
+                                CurrentAddress::PageAfter(current_page)
+                            } else {
+                                CurrentAddress::Address(next_address)
+                            };
+                            data_buffer.replace(db);
+                            continue;
+                        }
+                        item::MaybeItem::Erased(_) => unreachable!("Item is already erased"),
+                        item::MaybeItem::Present(item) => {
+                            let next_address =
+                                item.header.next_item_address::<S>(found_item_address);
+                            self.current_address = if next_address >= page_data_end_address {
+                                CurrentAddress::PageAfter(current_page)
+                            } else {
+                                CurrentAddress::Address(next_address)
+                            };
+                            // Return the item we found
+                            return Ok(Some((item, found_item_address)));
+                        }
                     }
-                    item::MaybeItem::Erased(_) => unreachable!("Item is already erased"),
-                    item::MaybeItem::Present(item) => {
-                        let next_address = item.header.next_item_address::<S>(found_item_address);
-                        self.current_address = if next_address >= page_data_end_address {
-                            CurrentAddress::PageAfter(current_page)
-                        } else {
-                            CurrentAddress::Address(next_address)
-                        };
-                        // Return the item we found
-                        return Ok(Some((item, found_item_address)));
-                    }
+                } else {
+                    self.current_address = CurrentAddress::PageAfter(current_page);
+                    break;
                 }
-            } else {
-                self.current_address = CurrentAddress::PageAfter(current_page);
             }
         }
     }
@@ -428,7 +438,7 @@ struct QueueIteratorResetPoint(CurrentAddress);
 /// data that can be stored, taking alignment requirements of the item into account.
 ///
 /// If there is no space left, `None` is returned.
-pub fn find_max_fit<S: NorFlash>(
+pub async fn find_max_fit<S: NorFlash>(
     flash: &mut S,
     flash_range: Range<u32>,
 ) -> Result<Option<u32>, Error<S::Error>> {
@@ -438,13 +448,13 @@ pub fn find_max_fit<S: NorFlash>(
     assert!(S::ERASE_SIZE >= S::WORD_SIZE * 4);
     assert!(S::WORD_SIZE <= MAX_WORD_SIZE);
 
-    let current_page = find_youngest_page(flash, flash_range.clone())?;
+    let current_page = find_youngest_page(flash, flash_range.clone()).await?;
 
     // Check if we have space on the next page
     let next_page = next_page::<S>(flash_range.clone(), current_page);
-    match get_page_state(flash, flash_range.clone(), next_page)? {
+    match get_page_state(flash, flash_range.clone(), next_page).await? {
         state @ PageState::Closed => {
-            if is_page_empty(flash, flash_range.clone(), next_page, Some(state))? {
+            if is_page_empty(flash, flash_range.clone(), next_page, Some(state)).await? {
                 return Ok(Some((S::ERASE_SIZE - (2 * S::WORD_SIZE)) as u32));
             }
         }
@@ -466,31 +476,29 @@ pub fn find_max_fit<S: NorFlash>(
     let page_data_end_address =
         calculate_page_end_address::<S>(flash_range.clone(), current_page) - S::WORD_SIZE as u32;
 
-    let next_item_address = read_item_headers(
-        flash,
-        page_data_start_address,
-        page_data_end_address,
-        |_, _, _| ControlFlow::<(), ()>::Continue(()),
-    )?
-    .1;
+    let next_item_address = HeaderIter::new(page_data_start_address, page_data_end_address)
+        .traverse(flash, |_, _| ControlFlow::Continue(()))
+        .await?
+        .1;
 
     Ok(ItemHeader::available_data_bytes::<S>(
         page_data_end_address - next_item_address,
     ))
 }
 
-fn find_youngest_page<S: NorFlash>(
+async fn find_youngest_page<S: NorFlash>(
     flash: &mut S,
     flash_range: Range<u32>,
 ) -> Result<usize, Error<S::Error>> {
-    let last_used_page = find_first_page(flash, flash_range.clone(), 0, PageState::PartialOpen)?;
+    let last_used_page =
+        find_first_page(flash, flash_range.clone(), 0, PageState::PartialOpen).await?;
 
     if let Some(last_used_page) = last_used_page {
         return Ok(last_used_page);
     }
 
     // We have no partial open page. Search for an open page to start in
-    let first_open_page = find_first_page(flash, flash_range, 0, PageState::Open)?;
+    let first_open_page = find_first_page(flash, flash_range, 0, PageState::Open).await?;
 
     if let Some(first_open_page) = first_open_page {
         return Ok(first_open_page);
@@ -506,14 +514,15 @@ fn find_youngest_page<S: NorFlash>(
     })
 }
 
-fn find_oldest_page<S: NorFlash>(
+async fn find_oldest_page<S: NorFlash>(
     flash: &mut S,
     flash_range: Range<u32>,
 ) -> Result<usize, Error<S::Error>> {
-    let youngest_page = find_youngest_page(flash, flash_range.clone())?;
+    let youngest_page = find_youngest_page(flash, flash_range.clone()).await?;
 
     // The oldest page is the first non-open page after the youngest page
-    let oldest_closed_page = find_first_page(flash, flash_range, youngest_page, PageState::Closed)?;
+    let oldest_closed_page =
+        find_first_page(flash, flash_range, youngest_page, PageState::Closed).await?;
 
     Ok(oldest_closed_page.unwrap_or(youngest_page))
 }
@@ -528,11 +537,11 @@ fn find_oldest_page<S: NorFlash>(
 /// If this function or the function call after this crate returns [Error::Corrupted], then it's unlikely
 /// that the state can be recovered. To at least make everything function again at the cost of losing the data,
 /// erase the flash range.
-pub fn try_repair<S: NorFlash>(
+pub async fn try_repair<S: NorFlash>(
     flash: &mut S,
     flash_range: Range<u32>,
 ) -> Result<(), Error<S::Error>> {
-    crate::try_general_repair(flash, flash_range.clone())?;
+    crate::try_general_repair(flash, flash_range.clone()).await?;
 
     Ok(())
 }
@@ -542,6 +551,7 @@ mod tests {
     use crate::mock_flash::WriteCountCheck;
 
     use super::*;
+    use futures::executor::block_on;
 
     type MockFlashBig = mock_flash::MockFlashBase<4, 4, 256>;
     type MockFlashTiny = mock_flash::MockFlashBase<2, 1, 32>;
@@ -554,62 +564,86 @@ mod tests {
         const DATA_SIZE: usize = 22;
 
         assert_eq!(
-            peek(&mut flash, flash_range.clone(), &mut data_buffer).unwrap(),
+            block_on(peek(&mut flash, flash_range.clone(), &mut data_buffer)).unwrap(),
             None
         );
 
-        push(&mut flash, flash_range.clone(), &[0xAA; DATA_SIZE], false).unwrap();
+        block_on(push(
+            &mut flash,
+            flash_range.clone(),
+            &[0xAA; DATA_SIZE],
+            false,
+        ))
+        .unwrap();
         assert_eq!(
-            &peek(&mut flash, flash_range.clone(), &mut data_buffer)
+            &block_on(peek(&mut flash, flash_range.clone(), &mut data_buffer))
                 .unwrap()
                 .unwrap()[..],
             &[0xAA; DATA_SIZE]
         );
-        push(&mut flash, flash_range.clone(), &[0xBB; DATA_SIZE], false).unwrap();
+        block_on(push(
+            &mut flash,
+            flash_range.clone(),
+            &[0xBB; DATA_SIZE],
+            false,
+        ))
+        .unwrap();
         assert_eq!(
-            &peek(&mut flash, flash_range.clone(), &mut data_buffer)
+            &block_on(peek(&mut flash, flash_range.clone(), &mut data_buffer))
                 .unwrap()
                 .unwrap()[..],
             &[0xAA; DATA_SIZE]
         );
 
         // Flash is full, this should fail
-        push(&mut flash, flash_range.clone(), &[0xCC; DATA_SIZE], false).unwrap_err();
+        block_on(push(
+            &mut flash,
+            flash_range.clone(),
+            &[0xCC; DATA_SIZE],
+            false,
+        ))
+        .unwrap_err();
         // Now we allow overwrite, so it should work
-        push(&mut flash, flash_range.clone(), &[0xDD; DATA_SIZE], true).unwrap();
+        block_on(push(
+            &mut flash,
+            flash_range.clone(),
+            &[0xDD; DATA_SIZE],
+            true,
+        ))
+        .unwrap();
 
         assert_eq!(
-            &peek(&mut flash, flash_range.clone(), &mut data_buffer)
+            &block_on(peek(&mut flash, flash_range.clone(), &mut data_buffer))
                 .unwrap()
                 .unwrap()[..],
             &[0xBB; DATA_SIZE]
         );
         assert_eq!(
-            &pop(&mut flash, flash_range.clone(), &mut data_buffer)
+            &block_on(pop(&mut flash, flash_range.clone(), &mut data_buffer))
                 .unwrap()
                 .unwrap()[..],
             &[0xBB; DATA_SIZE]
         );
 
         assert_eq!(
-            &peek(&mut flash, flash_range.clone(), &mut data_buffer)
+            &block_on(peek(&mut flash, flash_range.clone(), &mut data_buffer))
                 .unwrap()
                 .unwrap()[..],
             &[0xDD; DATA_SIZE]
         );
         assert_eq!(
-            &pop(&mut flash, flash_range.clone(), &mut data_buffer)
+            &block_on(pop(&mut flash, flash_range.clone(), &mut data_buffer))
                 .unwrap()
                 .unwrap()[..],
             &[0xDD; DATA_SIZE]
         );
 
         assert_eq!(
-            peek(&mut flash, flash_range.clone(), &mut data_buffer).unwrap(),
+            block_on(peek(&mut flash, flash_range.clone(), &mut data_buffer)).unwrap(),
             None
         );
         assert_eq!(
-            pop(&mut flash, flash_range.clone(), &mut data_buffer).unwrap(),
+            block_on(pop(&mut flash, flash_range.clone(), &mut data_buffer)).unwrap(),
             None
         );
     }
@@ -624,23 +658,23 @@ mod tests {
             println!("{i}");
             let data = vec![i as u8; i % 512 + 1];
 
-            push(&mut flash, flash_range.clone(), &data, true).unwrap();
+            block_on(push(&mut flash, flash_range.clone(), &data, true)).unwrap();
             assert_eq!(
-                &peek(&mut flash, flash_range.clone(), &mut data_buffer)
+                &block_on(peek(&mut flash, flash_range.clone(), &mut data_buffer))
                     .unwrap()
                     .unwrap()[..],
                 &data,
                 "At {i}"
             );
             assert_eq!(
-                &pop(&mut flash, flash_range.clone(), &mut data_buffer)
+                &block_on(pop(&mut flash, flash_range.clone(), &mut data_buffer))
                     .unwrap()
                     .unwrap()[..],
                 &data,
                 "At {i}"
             );
             assert_eq!(
-                peek(&mut flash, flash_range.clone(), &mut data_buffer).unwrap(),
+                block_on(peek(&mut flash, flash_range.clone(), &mut data_buffer)).unwrap(),
                 None,
                 "At {i}"
             );
@@ -653,30 +687,34 @@ mod tests {
         let flash_range = 0x00..0x40;
         let mut data_buffer = [0; 1024];
 
-        for i in 0..2000 {
+        for i in 0..1 {
             println!("{i}");
             let data = vec![i as u8; i % 20 + 1];
 
-            push(&mut flash, flash_range.clone(), &data, true).unwrap();
+            println!("PUSH");
+            block_on(push(&mut flash, flash_range.clone(), &data, true)).unwrap();
             assert_eq!(
-                &peek(&mut flash, flash_range.clone(), &mut data_buffer)
+                &block_on(peek(&mut flash, flash_range.clone(), &mut data_buffer))
                     .unwrap()
                     .unwrap()[..],
                 &data,
                 "At {i}"
             );
+            println!("POP");
             assert_eq!(
-                &pop(&mut flash, flash_range.clone(), &mut data_buffer)
+                &block_on(pop(&mut flash, flash_range.clone(), &mut data_buffer))
                     .unwrap()
                     .unwrap()[..],
                 &data,
                 "At {i}"
             );
+            println!("PEEK");
             assert_eq!(
-                peek(&mut flash, flash_range.clone(), &mut data_buffer).unwrap(),
+                block_on(peek(&mut flash, flash_range.clone(), &mut data_buffer)).unwrap(),
                 None,
                 "At {i}"
             );
+            println!("DONE");
         }
     }
 
@@ -696,26 +734,26 @@ mod tests {
 
             for i in 0..20 {
                 let data = vec![i as u8; 50];
-                push(&mut flash, flash_range.clone(), &data, false).unwrap();
+                block_on(push(&mut flash, flash_range.clone(), &data, false)).unwrap();
                 add_ops(&mut flash, &mut push_ops);
             }
 
-            let mut peeker = peek_many(&mut flash, flash_range.clone()).unwrap();
+            let mut peeker = block_on(peek_many(&mut flash, flash_range.clone())).unwrap();
             for i in 0..5 {
                 let mut data = vec![i as u8; 50];
                 assert_eq!(
-                    peeker.next(&mut data_buffer).unwrap(),
+                    block_on(peeker.next(&mut data_buffer)).unwrap(),
                     Some(&mut data[..]),
                     "At {i}"
                 );
                 add_ops(peeker.iter.flash, &mut peek_ops);
             }
 
-            let mut popper = pop_many(&mut flash, flash_range.clone()).unwrap();
+            let mut popper = block_on(pop_many(&mut flash, flash_range.clone())).unwrap();
             for i in 0..5 {
                 let data = vec![i as u8; 50];
                 assert_eq!(
-                    &popper.next(&mut data_buffer).unwrap().unwrap()[..],
+                    &block_on(popper.next(&mut data_buffer)).unwrap().unwrap()[..],
                     &data,
                     "At {i}"
                 );
@@ -724,26 +762,26 @@ mod tests {
 
             for i in 20..25 {
                 let data = vec![i as u8; 50];
-                push(&mut flash, flash_range.clone(), &data, false).unwrap();
+                block_on(push(&mut flash, flash_range.clone(), &data, false)).unwrap();
                 add_ops(&mut flash, &mut push_ops);
             }
 
-            let mut peeker = peek_many(&mut flash, flash_range.clone()).unwrap();
+            let mut peeker = block_on(peek_many(&mut flash, flash_range.clone())).unwrap();
             for i in 5..25 {
                 let data = vec![i as u8; 50];
                 assert_eq!(
-                    &peeker.next(&mut data_buffer).unwrap().unwrap()[..],
+                    &block_on(peeker.next(&mut data_buffer)).unwrap().unwrap()[..],
                     &data,
                     "At {i}"
                 );
                 add_ops(peeker.iter.flash, &mut peek_ops);
             }
 
-            let mut popper = pop_many(&mut flash, flash_range.clone()).unwrap();
+            let mut popper = block_on(pop_many(&mut flash, flash_range.clone())).unwrap();
             for i in 5..25 {
                 let data = vec![i as u8; 50];
                 assert_eq!(
-                    &popper.next(&mut data_buffer).unwrap().unwrap()[..],
+                    &block_on(popper.next(&mut data_buffer)).unwrap().unwrap()[..],
                     &data,
                     "At {i}"
                 );
@@ -775,14 +813,14 @@ mod tests {
 
             for i in 0..20 {
                 let data = vec![i as u8; 50];
-                push(&mut flash, flash_range.clone(), &data, false).unwrap();
+                block_on(push(&mut flash, flash_range.clone(), &data, false)).unwrap();
                 add_ops(&mut flash, &mut push_ops);
             }
 
             for i in 0..5 {
                 let data = vec![i as u8; 50];
                 assert_eq!(
-                    &pop(&mut flash, flash_range.clone(), &mut data_buffer)
+                    &block_on(pop(&mut flash, flash_range.clone(), &mut data_buffer))
                         .unwrap()
                         .unwrap()[..],
                     &data,
@@ -793,14 +831,14 @@ mod tests {
 
             for i in 20..25 {
                 let data = vec![i as u8; 50];
-                push(&mut flash, flash_range.clone(), &data, false).unwrap();
+                block_on(push(&mut flash, flash_range.clone(), &data, false)).unwrap();
                 add_ops(&mut flash, &mut push_ops);
             }
 
             for i in 5..25 {
                 let data = vec![i as u8; 50];
                 assert_eq!(
-                    &pop(&mut flash, flash_range.clone(), &mut data_buffer)
+                    &block_on(pop(&mut flash, flash_range.clone(), &mut data_buffer))
                         .unwrap()
                         .unwrap()[..],
                     &data,
@@ -856,19 +894,19 @@ mod tests {
         let flash_range = 0x00..0x40;
         let mut data_buffer = [0; 1024];
 
-        push(&mut flash, flash_range.clone(), &[0xAA; 20], false).unwrap();
-        push(&mut flash, flash_range.clone(), &[0xBB; 20], false).unwrap();
+        block_on(push(&mut flash, flash_range.clone(), &[0xAA; 20], false)).unwrap();
+        block_on(push(&mut flash, flash_range.clone(), &[0xBB; 20], false)).unwrap();
 
         // There's now an unused gap at the end of the first page
 
         assert_eq!(
-            &pop(&mut flash, flash_range.clone(), &mut data_buffer)
+            &block_on(pop(&mut flash, flash_range.clone(), &mut data_buffer))
                 .unwrap()
                 .unwrap()[..],
             &[0xAA; 20]
         );
         assert_eq!(
-            &pop(&mut flash, flash_range.clone(), &mut data_buffer)
+            &block_on(pop(&mut flash, flash_range.clone(), &mut data_buffer))
                 .unwrap()
                 .unwrap()[..],
             &[0xBB; 20]
@@ -881,11 +919,17 @@ mod tests {
 
         const FLASH_RANGE: Range<u32> = 0x000..0x1000;
 
-        close_page(&mut flash, FLASH_RANGE, 0).unwrap();
-        close_page(&mut flash, FLASH_RANGE, 1).unwrap();
-        partial_close_page(&mut flash, FLASH_RANGE, 2).unwrap();
+        block_on(close_page(&mut flash, FLASH_RANGE, 0)).unwrap();
+        block_on(close_page(&mut flash, FLASH_RANGE, 1)).unwrap();
+        block_on(partial_close_page(&mut flash, FLASH_RANGE, 2)).unwrap();
 
-        assert_eq!(find_youngest_page(&mut flash, FLASH_RANGE).unwrap(), 2);
-        assert_eq!(find_oldest_page(&mut flash, FLASH_RANGE).unwrap(), 0);
+        assert_eq!(
+            block_on(find_youngest_page(&mut flash, FLASH_RANGE)).unwrap(),
+            2
+        );
+        assert_eq!(
+            block_on(find_oldest_page(&mut flash, FLASH_RANGE)).unwrap(),
+            0
+        );
     }
 }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -375,13 +375,7 @@ impl<'d, S: NorFlash> QueueIterator<'d, S> {
             // Search for the first item with data
             let mut it = ItemHeaderIter::new(current_address, page_data_end_address);
             if let (Some(found_item_header), found_item_address) = it
-                .traverse(self.flash, |header, _| {
-                    if header.crc.is_some() {
-                        ControlFlow::Break(())
-                    } else {
-                        ControlFlow::Continue(())
-                    }
-                })
+                .traverse(self.flash, |header, _| header.crc.is_none())
                 .await?
             {
                 let maybe_item = found_item_header
@@ -477,7 +471,7 @@ pub async fn find_max_fit<S: NorFlash>(
         calculate_page_end_address::<S>(flash_range.clone(), current_page) - S::WORD_SIZE as u32;
 
     let next_item_address = ItemHeaderIter::new(page_data_start_address, page_data_end_address)
-        .traverse(flash, |_, _| ControlFlow::Continue(()))
+        .traverse(flash, |_, _| true)
         .await?
         .1;
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -56,7 +56,7 @@
 //! });
 //! ```
 
-use crate::item::{find_next_free_item_spot, is_page_empty, HeaderIter, Item, ItemHeader};
+use crate::item::{find_next_free_item_spot, is_page_empty, Item, ItemHeader, ItemHeaderIter};
 
 use super::*;
 use embedded_storage_async::nor_flash::MultiwriteNorFlash;
@@ -373,7 +373,7 @@ impl<'d, S: NorFlash> QueueIterator<'d, S> {
                     - S::WORD_SIZE as u32;
 
             // Search for the first item with data
-            let mut it = HeaderIter::new(current_address, page_data_end_address);
+            let mut it = ItemHeaderIter::new(current_address, page_data_end_address);
             loop {
                 if let (Some(found_item_header), found_item_address) = it
                     .traverse(self.flash, |header, _| {
@@ -481,7 +481,7 @@ pub async fn find_max_fit<S: NorFlash>(
     let page_data_end_address =
         calculate_page_end_address::<S>(flash_range.clone(), current_page) - S::WORD_SIZE as u32;
 
-    let next_item_address = HeaderIter::new(page_data_start_address, page_data_end_address)
+    let next_item_address = ItemHeaderIter::new(page_data_start_address, page_data_end_address)
         .traverse(flash, |_, _| ControlFlow::Continue(()))
         .await?
         .1;


### PR DESCRIPTION
@diondokter Just a headsup that I started looking at this... I've gotten the queue implementation to work nicely with async, and was able to use it with the Flash on nrf-softdevice. This revealed an issue which might be only specific to the softdevice, where the buffer to write into flash must be word-aligned, so the AlignedBuf is introduced for that. I set the alignment to 32 bytes, but I'm not sure if there are anyone besides the nRF flash which has this requirement (could be set to 4 bytes in that case).

I need to finish the map support, but just thought to give an early notice!