### PR TITLE
Adding ability to remove all keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added `erase_all` function as a helper to erase the flash in a region.
 - *Breaking:* Changed the way that queue iteration works. Now there's an `iter` function instead of two separate `peek_many` and `pop_many` functions. The new iter returns an entry from which you can get the data that was just peeked. If you want to pop it, then call the pop function on the entry.
 - Added `arrayvec` feature that when activated impls the `Key` trait for `ArrayVec` and `ArrayString`.
+- Added a new `map::remove_all_items()` API to remove all stored items in flash.
 
 ## 1.0.0 01-03-24
 


### PR DESCRIPTION
Fixes https://github.com/tweedegolf/sequential-storage/issues/47 by adding a `remove_all_items()` function to `map` to erase all of the saved keys using an overwrite mechanism. This prevents needing to erase device flash, which could take a long time.

The benefit of this approach is that flash erasure counts are minimized, as you need to loop through all of flash before anything ever needs to be erased.

I haven't tested this on hardware yet, so leaving it as a draft.