### PR TITLE
Adjust check-cfg for Rust 1.76 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ std = []
 # Enable the implementation of the map Key trait for ArrayVec and ArrayString
 arrayvec = ["dep:arrayvec"]
 _test = ["dep:futures", "dep:approx", "std", "arrayvec"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing_repro)'] }

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("cargo::rustc-check-cfg=cfg(fuzzing_repro)");
-}


### PR DESCRIPTION
This commit moves the lint config for check-cfg from build.rs to Cargo.toml. This change ensures compatibility with Rust versions <=1.76 while silencing cfg warnings in newer versions.

Further refrence: https://blog.rust-lang.org/2024/05/06/check-cfg.html#expecting-custom-cfgs

It also fixes the actual problem mentioned in #55