### PR TITLE
Queue iterator no longer takes reference to flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - *Breaking:* Added `Value` impls for `bool`, `Option<T: Value>`, and `[T: Value; N]`.
   *This can break existing code because it changes type inference, be mindfull of that!*
+- *Breaking:* Queue iterators no longer take reference to the flash instance. Instead, iterator method signatures change to take a reference to the flash instance.
 
 ## 3.0.1 25-07-24
 

--- a/fuzz/fuzz_targets/queue.rs
+++ b/fuzz/fuzz_targets/queue.rs
@@ -235,7 +235,7 @@ fn fuzz(ops: Input, mut cache: impl CacheImpl + Debug) {
 
                 let mut popped_items = 0;
                 for (i, do_pop) in pop_sequence.iter().enumerate() {
-                    match block_on(iterator.next(&mut buf.0)) {
+                    match block_on(iterator.next(&mut flash, &mut buf.0)) {
                         Ok(Some(value)) => {
                             assert_eq!(
                                 &*value,
@@ -243,7 +243,7 @@ fn fuzz(ops: Input, mut cache: impl CacheImpl + Debug) {
                             );
 
                             if *do_pop {
-                                let popped = block_on(value.pop());
+                                let popped = block_on(value.pop(&mut flash));
 
                                 match popped {
                                     Ok(value) => {


### PR DESCRIPTION
Apologies for just dumping this PR without discussion first, but I wanted to validate the idea anyway before raising the PR, hopefully making it clearer what API i desire.

This permits more flexible use of the iterator, for instance if needing to perform flash operations based on some error while iterating.  In the current API, the flash is held exclusively by the iterator, which prevents reading and/or writing to flash (in some unrelated region) while iterating.