### PR TITLE
Add `Key` implementation for the unit type `()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Unreleased
 
+- Added `Key` implementation for the unit type `()` for easy storage of a single value
+
 ## 4.0.3 18-06-25
 
 - Fixed queue regression introduced in 2.0.0. It used to erase pages opportunistically for better performance.


### PR DESCRIPTION
For applications where you want to quickly store a single state value, and do not want to bother with pushing and popping on a queue.