### PR TITLE
Capture `Key` in `MapItemIter` for map `fetch_all_items`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Unreleased
 
 - Added `Key` implementation for the unit type `()` for easy storage of a single value
+- Changed API for map `fetch_all_items` such that the `Key` is captured in `MapItemIter`.
 
 ## 4.0.3 18-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Unreleased
 
 - Added `Key` implementation for the unit type `()` for easy storage of a single value
-- Changed API for map `fetch_all_items` such that the `Key` is captured in `MapItemIter`.
+- *Breaking:* Changed API for map `fetch_all_items` such that the `Key` is captured in `MapItemIter`.
 
 ## 4.0.3 18-06-25
 

--- a/fuzz/fuzz_targets/map.rs
+++ b/fuzz/fuzz_targets/map.rs
@@ -286,7 +286,7 @@ fn fuzz(ops: Input, mut cache: impl KeyCacheImpl<u8> + Debug) {
                 let mut seen_items = HashMap::new();
 
                 loop {
-                    match block_on(iter.next::<u8, &[u8]>(&mut buf.0)) {
+                    match block_on(iter.next::<&[u8]>(&mut buf.0)) {
                         Ok(None) => break,
                         Ok(Some((key, val))) => {
                             seen_items.insert(key, val.to_vec());


### PR DESCRIPTION
When using `fetch_all_items` for every call of `next` the user must pass the correct `Key`. We can leverage `PhantomData` such that the user can not mistakenly pass the wrong type.

This PR breaks API stability.