### PR TITLE
feat(map)!: add Send + Sync supertraits to Value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Unreleased
 
+- *Breaking:* Added `Send + Sync` supertraits to `Value` so that futures returned by `MapStorage` methods are `Send`
+
 ## 7.2.0 - 24-03-26
 
 - Added a RAM-buffered queue

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -578,7 +578,7 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sequential-storage"
-version = "7.1.0"
+version = "7.2.0"
 dependencies = [
  "defmt",
  "embedded-storage-async",

--- a/src/map.rs
+++ b/src/map.rs
@@ -1143,7 +1143,7 @@ impl Key for () {
 ///
 /// It also carries a lifetime so that zero-copy deserialization is supported.
 /// Zero-copy serialization is not supported due to technical restrictions.
-pub trait Value<'a> {
+pub trait Value<'a>: Send + Sync {
     /// Serialize the value into the given buffer. If everything went ok, this function returns the length
     /// of the used part of the buffer.
     fn serialize_into(&self, buffer: &mut [u8]) -> Result<usize, SerializationError>;
@@ -1887,4 +1887,20 @@ mod tests {
             Ok((Foo(123), 1))
         );
     }
+
+    /// Compile-time check: the future returned by `store_item` must be `Send`
+    /// when all components are `Send`. See https://github.com/tweedegolf/sequential-storage/issues/125
+    fn _assert_store_item_future_is_send() {
+        fn assert_send<T: Send>(_t: T) {}
+
+        let mut storage = MapStorage::<u8, _, _>::new(
+            MockFlashBig::default(),
+            MapConfig::new(0x000..0x1000),
+            NoCache::new(),
+        );
+        let mut data_buffer = AlignedBuf([0; 128]);
+
+        assert_send(storage.store_item(&mut data_buffer, &0u8, &42u32));
+    }
+
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -139,6 +139,157 @@ pub struct MapStorage<K: Key, S: NorFlash, C: KeyCacheImpl<K>> {
     _phantom: PhantomData<K>,
 }
 
+/// Shared body for [`MapStorage::store_item_inner`] and [`MapStorage::store_item_inner_local`].
+/// The two differ only in the trait-object bound on `item` (Send+Sync vs bare); the logic
+/// is identical, so it lives here as a macro to keep a single source of truth.
+macro_rules! store_item_body {
+    ($this:ident, $data_buffer:ident, $key:ident, $item:ident) => {{
+        if $this.inner.cache.is_dirty() {
+            $this.inner.cache.invalidate_cache_state();
+        }
+
+        let mut recursion_level = 0;
+        loop {
+            // Check if we're in an infinite recursion which happens when we don't have enough space to store the new data
+            if recursion_level == $this.inner.get_pages(0).count() {
+                $this.inner.cache.unmark_dirty();
+                return Err(Error::FullStorage);
+            }
+
+            // If there is a partial open page, we try to write in that first if there is enough space
+            let next_page_to_use = if let Some(partial_open_page) = $this
+                .inner
+                .find_first_page(0, PageState::PartialOpen)
+                .await?
+            {
+                // We found a partial open page, but at this point it's relatively cheap to do a consistency check
+                if !$this
+                    .inner
+                    .get_page_state($this.inner.next_page(partial_open_page))
+                    .await?
+                    .is_open()
+                {
+                    // Oh oh, the next page which serves as the buffer page is not open. We're corrupt.
+                    // This likely happened because of an unexpected shutdown during data migration from the
+                    // then new buffer page to the new partial open page.
+                    // The repair function should be able to repair this.
+                    return Err(Error::Corrupted {
+                        #[cfg(feature = "_test")]
+                        backtrace: std::backtrace::Backtrace::capture(),
+                    });
+                }
+
+                // We've got to search where the free space is since the page starts with items present already
+
+                let page_data_start_address =
+                    calculate_page_address::<S>($this.flash_range(), partial_open_page)
+                        + S::WORD_SIZE as u32;
+                let page_data_end_address =
+                    calculate_page_end_address::<S>($this.flash_range(), partial_open_page)
+                        - S::WORD_SIZE as u32;
+
+                let key_len = $key.serialize_into($data_buffer)?;
+                let item_data_length = key_len
+                    + $item
+                        .serialize_into(&mut $data_buffer[key_len..])
+                        .map_err(Error::SerializationError)?;
+
+                if item_data_length > u16::MAX as usize
+                    || item_data_length
+                        > calculate_page_size::<S>()
+                            .saturating_sub(ItemHeader::data_address::<S>(0) as usize)
+                {
+                    $this.inner.cache.unmark_dirty();
+                    return Err(Error::ItemTooBig);
+                }
+
+                let free_spot_address = $this
+                    .inner
+                    .find_next_free_item_spot(
+                        page_data_start_address,
+                        page_data_end_address,
+                        item_data_length as u32,
+                    )
+                    .await?;
+
+                if let Some(free_spot_address) = free_spot_address {
+                    $this
+                        .inner
+                        .cache
+                        .notice_key_location($key, free_spot_address, true);
+                    Item::write_new(
+                        &mut $this.inner.flash,
+                        $this.inner.flash_range.clone(),
+                        &mut $this.inner.cache,
+                        free_spot_address,
+                        &$data_buffer[..item_data_length],
+                    )
+                    .await?;
+
+                    $this.inner.cache.unmark_dirty();
+                    return Ok(());
+                }
+
+                // The item doesn't fit here, so we need to close this page and move to the next
+                $this.inner.close_page(partial_open_page).await?;
+                Some($this.inner.next_page(partial_open_page))
+            } else {
+                None
+            };
+
+            // If we get here, there was no partial page found or the partial page has now been closed because the item didn't fit.
+            // If there was a partial page, then we need to look at the next page. It's supposed to be open since it was the previous empty buffer page.
+            // The new buffer page has to be emptied if it was closed.
+            // If there was no partial page, we just use the first open page.
+
+            if let Some(next_page_to_use) = next_page_to_use {
+                let next_page_state = $this.inner.get_page_state(next_page_to_use).await?;
+
+                if !next_page_state.is_open() {
+                    // What was the previous buffer page was not open...
+                    return Err(Error::Corrupted {
+                        #[cfg(feature = "_test")]
+                        backtrace: std::backtrace::Backtrace::capture(),
+                    });
+                }
+
+                // Since we're gonna write data here, let's already partially close the page
+                // This could be done after moving the data, but this is more robust in the
+                // face of shutdowns and cancellations
+                $this.inner.partial_close_page(next_page_to_use).await?;
+
+                let next_buffer_page = $this.inner.next_page(next_page_to_use);
+                let next_buffer_page_state =
+                    $this.inner.get_page_state(next_buffer_page).await?;
+
+                if !next_buffer_page_state.is_open() {
+                    $this
+                        .migrate_items($data_buffer, next_buffer_page, next_page_to_use)
+                        .await?;
+                }
+            } else {
+                // There's no partial open page, so we just gotta turn the first open page into a partial open one
+                let Some(first_open_page) =
+                    $this.inner.find_first_page(0, PageState::Open).await?
+                else {
+                    // Uh oh, no open pages.
+                    // Something has gone wrong.
+                    // We should never get here.
+                    return Err(Error::Corrupted {
+                        #[cfg(feature = "_test")]
+                        backtrace: std::backtrace::Backtrace::capture(),
+                    });
+                };
+
+                $this.inner.partial_close_page(first_open_page).await?;
+            }
+
+            // If we get here, we just freshly partially closed a new page, so the next loop iteration should succeed.
+            recursion_level += 1;
+        }
+    }};
+}
+
 impl<S: NorFlash, C: KeyCacheImpl<K>, K: Key> MapStorage<K, S, C> {
     /// Create a new map instance
     ///
@@ -369,6 +520,10 @@ impl<S: NorFlash, C: KeyCacheImpl<K>, K: Key> MapStorage<K, S, C> {
     ///
     /// The data buffer must be long enough to hold the longest serialized data of your [Key] + [Value] types combined,
     /// rounded up to flash word alignment.
+    ///
+    /// The returned future is `Send`, so this method is usable from multi-threaded executors.
+    /// If your `Value` type isn't `Send + Sync` (e.g. it contains a [`core::cell::RefCell`]),
+    /// use [`Self::store_item_local`] instead.
     pub async fn store_item<'d, V: Value<'d> + Send + Sync>(
         &mut self,
         data_buffer: &mut [u8],
@@ -381,151 +536,39 @@ impl<S: NorFlash, C: KeyCacheImpl<K>, K: Key> MapStorage<K, S, C> {
         )
     }
 
+    /// Like [`Self::store_item`], but works with `Value` types that aren't `Send + Sync`.
+    ///
+    /// The returned future is **not** `Send`, so this method is only suitable for
+    /// single-threaded executors. In exchange, `V` may contain non-`Sync` interior
+    /// mutability (e.g. [`core::cell::RefCell`]).
+    pub async fn store_item_local<'d, V: Value<'d>>(
+        &mut self,
+        data_buffer: &mut [u8],
+        key: &K,
+        item: &V,
+    ) -> Result<(), Error<S::Error>> {
+        run_with_auto_repair!(
+            function = self.store_item_inner_local(data_buffer, key, item).await,
+            repair = self.try_repair(data_buffer).await?
+        )
+    }
+
     async fn store_item_inner(
         &mut self,
         data_buffer: &mut [u8],
         key: &K,
         item: &(dyn Value<'_> + Send + Sync),
     ) -> Result<(), Error<S::Error>> {
-        if self.inner.cache.is_dirty() {
-            self.inner.cache.invalidate_cache_state();
-        }
+        store_item_body!(self, data_buffer, key, item)
+    }
 
-        let mut recursion_level = 0;
-        loop {
-            // Check if we're in an infinite recursion which happens when we don't have enough space to store the new data
-            if recursion_level == self.inner.get_pages(0).count() {
-                self.inner.cache.unmark_dirty();
-                return Err(Error::FullStorage);
-            }
-
-            // If there is a partial open page, we try to write in that first if there is enough space
-            let next_page_to_use = if let Some(partial_open_page) = self
-                .inner
-                .find_first_page(0, PageState::PartialOpen)
-                .await?
-            {
-                // We found a partial open page, but at this point it's relatively cheap to do a consistency check
-                if !self
-                    .inner
-                    .get_page_state(self.inner.next_page(partial_open_page))
-                    .await?
-                    .is_open()
-                {
-                    // Oh oh, the next page which serves as the buffer page is not open. We're corrupt.
-                    // This likely happened because of an unexpected shutdown during data migration from the
-                    // then new buffer page to the new partial open page.
-                    // The repair function should be able to repair this.
-                    return Err(Error::Corrupted {
-                        #[cfg(feature = "_test")]
-                        backtrace: std::backtrace::Backtrace::capture(),
-                    });
-                }
-
-                // We've got to search where the free space is since the page starts with items present already
-
-                let page_data_start_address =
-                    calculate_page_address::<S>(self.flash_range(), partial_open_page)
-                        + S::WORD_SIZE as u32;
-                let page_data_end_address =
-                    calculate_page_end_address::<S>(self.flash_range(), partial_open_page)
-                        - S::WORD_SIZE as u32;
-
-                let key_len = key.serialize_into(data_buffer)?;
-                let item_data_length = key_len
-                    + item
-                        .serialize_into(&mut data_buffer[key_len..])
-                        .map_err(Error::SerializationError)?;
-
-                if item_data_length > u16::MAX as usize
-                    || item_data_length
-                        > calculate_page_size::<S>()
-                            .saturating_sub(ItemHeader::data_address::<S>(0) as usize)
-                {
-                    self.inner.cache.unmark_dirty();
-                    return Err(Error::ItemTooBig);
-                }
-
-                let free_spot_address = self
-                    .inner
-                    .find_next_free_item_spot(
-                        page_data_start_address,
-                        page_data_end_address,
-                        item_data_length as u32,
-                    )
-                    .await?;
-
-                if let Some(free_spot_address) = free_spot_address {
-                    self.inner
-                        .cache
-                        .notice_key_location(key, free_spot_address, true);
-                    Item::write_new(
-                        &mut self.inner.flash,
-                        self.inner.flash_range.clone(),
-                        &mut self.inner.cache,
-                        free_spot_address,
-                        &data_buffer[..item_data_length],
-                    )
-                    .await?;
-
-                    self.inner.cache.unmark_dirty();
-                    return Ok(());
-                }
-
-                // The item doesn't fit here, so we need to close this page and move to the next
-                self.inner.close_page(partial_open_page).await?;
-                Some(self.inner.next_page(partial_open_page))
-            } else {
-                None
-            };
-
-            // If we get here, there was no partial page found or the partial page has now been closed because the item didn't fit.
-            // If there was a partial page, then we need to look at the next page. It's supposed to be open since it was the previous empty buffer page.
-            // The new buffer page has to be emptied if it was closed.
-            // If there was no partial page, we just use the first open page.
-
-            if let Some(next_page_to_use) = next_page_to_use {
-                let next_page_state = self.inner.get_page_state(next_page_to_use).await?;
-
-                if !next_page_state.is_open() {
-                    // What was the previous buffer page was not open...
-                    return Err(Error::Corrupted {
-                        #[cfg(feature = "_test")]
-                        backtrace: std::backtrace::Backtrace::capture(),
-                    });
-                }
-
-                // Since we're gonna write data here, let's already partially close the page
-                // This could be done after moving the data, but this is more robust in the
-                // face of shutdowns and cancellations
-                self.inner.partial_close_page(next_page_to_use).await?;
-
-                let next_buffer_page = self.inner.next_page(next_page_to_use);
-                let next_buffer_page_state = self.inner.get_page_state(next_buffer_page).await?;
-
-                if !next_buffer_page_state.is_open() {
-                    self.migrate_items(data_buffer, next_buffer_page, next_page_to_use)
-                        .await?;
-                }
-            } else {
-                // There's no partial open page, so we just gotta turn the first open page into a partial open one
-                let Some(first_open_page) = self.inner.find_first_page(0, PageState::Open).await?
-                else {
-                    // Uh oh, no open pages.
-                    // Something has gone wrong.
-                    // We should never get here.
-                    return Err(Error::Corrupted {
-                        #[cfg(feature = "_test")]
-                        backtrace: std::backtrace::Backtrace::capture(),
-                    });
-                };
-
-                self.inner.partial_close_page(first_open_page).await?;
-            }
-
-            // If we get here, we just freshly partially closed a new page, so the next loop iteration should succeed.
-            recursion_level += 1;
-        }
+    async fn store_item_inner_local(
+        &mut self,
+        data_buffer: &mut [u8],
+        key: &K,
+        item: &dyn Value<'_>,
+    ) -> Result<(), Error<S::Error>> {
+        store_item_body!(self, data_buffer, key, item)
     }
 
     /// Fully remove an item. Additional calls to fetch with the same key will return None until
@@ -1902,5 +1945,33 @@ mod tests {
 
         assert_send(storage.store_item(&mut data_buffer, &0u8, &42u32));
         assert_send(storage.fetch_item::<u32>(&mut data_buffer, &0u8));
+    }
+
+    /// Compile-time check: `store_item_local` accepts non-`Sync` value types
+    /// (like those containing a `RefCell`). The returned future is intentionally
+    /// not required to be `Send`.
+    fn _assert_store_item_local_accepts_non_sync() {
+        use core::cell::RefCell;
+
+        struct NotSync(RefCell<u32>);
+        impl<'a> Value<'a> for NotSync {
+            fn serialize_into(&self, buffer: &mut [u8]) -> Result<usize, SerializationError> {
+                <u32 as Value>::serialize_into(&self.0.borrow(), buffer)
+            }
+            fn deserialize_from(buffer: &'a [u8]) -> Result<(Self, usize), SerializationError> {
+                let (v, n) = <u32 as Value>::deserialize_from(buffer)?;
+                Ok((NotSync(RefCell::new(v)), n))
+            }
+        }
+
+        let mut storage = MapStorage::<u8, _, _>::new(
+            MockFlashBig::default(),
+            MapConfig::new(0x000..0x1000),
+            NoCache::new(),
+        );
+        let mut data_buffer = AlignedBuf([0; 128]);
+        let item = NotSync(RefCell::new(42));
+
+        let _fut = storage.store_item_local(&mut data_buffer, &0u8, &item);
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -1238,7 +1238,7 @@ pub trait PostcardValue<'a>: Serialize + Deserialize<'a> {}
 #[cfg(feature = "postcard")]
 impl<'a, T> Value<'a> for T
 where
-    T: PostcardValue<'a>,
+    T: PostcardValue<'a> + Send + Sync,
 {
     fn serialize_into(&self, buffer: &mut [u8]) -> Result<usize, SerializationError> {
         Ok(postcard::to_slice(self, buffer).map(|s| s.len())?)
@@ -1888,9 +1888,9 @@ mod tests {
         );
     }
 
-    /// Compile-time check: the future returned by `store_item` must be `Send`
-    /// when all components are `Send`. See https://github.com/tweedegolf/sequential-storage/issues/125
-    fn _assert_store_item_future_is_send() {
+    /// Compile-time check: the futures returned by `store_item` and `fetch_item`
+    /// must be `Send`. See https://github.com/tweedegolf/sequential-storage/issues/125
+    fn _assert_public_futures_are_send() {
         fn assert_send<T: Send>(_t: T) {}
 
         let mut storage = MapStorage::<u8, _, _>::new(
@@ -1901,6 +1901,6 @@ mod tests {
         let mut data_buffer = AlignedBuf([0; 128]);
 
         assert_send(storage.store_item(&mut data_buffer, &0u8, &42u32));
+        assert_send(storage.fetch_item::<u32>(&mut data_buffer, &0u8));
     }
-
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -369,7 +369,7 @@ impl<S: NorFlash, C: KeyCacheImpl<K>, K: Key> MapStorage<K, S, C> {
     ///
     /// The data buffer must be long enough to hold the longest serialized data of your [Key] + [Value] types combined,
     /// rounded up to flash word alignment.
-    pub async fn store_item<'d, V: Value<'d>>(
+    pub async fn store_item<'d, V: Value<'d> + Send + Sync>(
         &mut self,
         data_buffer: &mut [u8],
         key: &K,
@@ -385,7 +385,7 @@ impl<S: NorFlash, C: KeyCacheImpl<K>, K: Key> MapStorage<K, S, C> {
         &mut self,
         data_buffer: &mut [u8],
         key: &K,
-        item: &dyn Value<'_>,
+        item: &(dyn Value<'_> + Send + Sync),
     ) -> Result<(), Error<S::Error>> {
         if self.inner.cache.is_dirty() {
             self.inner.cache.invalidate_cache_state();
@@ -1143,7 +1143,7 @@ impl Key for () {
 ///
 /// It also carries a lifetime so that zero-copy deserialization is supported.
 /// Zero-copy serialization is not supported due to technical restrictions.
-pub trait Value<'a>: Send + Sync {
+pub trait Value<'a> {
     /// Serialize the value into the given buffer. If everything went ok, this function returns the length
     /// of the used part of the buffer.
     fn serialize_into(&self, buffer: &mut [u8]) -> Result<usize, SerializationError>;
@@ -1238,7 +1238,7 @@ pub trait PostcardValue<'a>: Serialize + Deserialize<'a> {}
 #[cfg(feature = "postcard")]
 impl<'a, T> Value<'a> for T
 where
-    T: PostcardValue<'a> + Send + Sync,
+    T: PostcardValue<'a>,
 {
     fn serialize_into(&self, buffer: &mut [u8]) -> Result<usize, SerializationError> {
         Ok(postcard::to_slice(self, buffer).map(|s| s.len())?)


### PR DESCRIPTION
## Summary

- Add `Send + Sync` supertraits to the `Value` trait so that futures returned by `MapStorage::store_item` (and other methods) are `Send`.
- `store_item_inner` uses `&dyn Value<'_>` internally. For `&dyn T` to be `Send`, `T` must be `Sync` — without the supertrait, the future is `!Send` even when the concrete value type is `Send + Sync`.
- All existing `Value` implementations (primitives, `&[u8]`, `Option<T>`, postcard types) are already `Send + Sync`, so this is unlikely to break real-world code.
- Adds a compile-time assertion test to prevent regression.

## Changes

- `src/map.rs`: `Value<'a>` now requires `Send + Sync`
- `src/map.rs`: Added `_assert_store_item_future_is_send` compile-time test
- `CHANGELOG.md`: Added breaking change entry under Unreleased

## Related Issues

Closes #125

## Test Plan

- All 52 existing unit tests pass
- New compile-time test verifies the `store_item` future is `Send`
- Removing the supertraits causes the new test to fail with the expected error